### PR TITLE
fix: Load ALLOWED_HOSTS dynamically from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ DB_USER=db_user
 DB_PASSWORD=db_password
 DB_HOST=db_host
 DB_PORT=db_port
+
+ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com,127.0.0.1

--- a/OBEAutomation/settings.py
+++ b/OBEAutomation/settings.py
@@ -29,8 +29,11 @@ SECRET_KEY = 'django-insecure-arz*%42w(xuq(v^46&4*zswm7^k4+so0-1=*8lfb6ia^#i7nbp
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
+ALLOWED_HOSTS_ENV = os.environ.get('ALLOWED_HOSTS', '')
+if ALLOWED_HOSTS_ENV:
+    ALLOWED_HOSTS = [host.strip() for host in ALLOWED_HOSTS_ENV.split(',')]
+else:
+    ALLOWED_HOSTS = []
 
 # Application definition
 


### PR DESCRIPTION
Update settings.py to populate ALLOWED_HOSTS from the .env configuration, improving deployment security. Also appended the new ALLOWED_HOSTS variable to .env.example.